### PR TITLE
Issue #6: Expose the range an array formula spills across

### DIFF
--- a/include/xlnt/cell/cell.hpp
+++ b/include/xlnt/cell/cell.hpp
@@ -41,6 +41,7 @@ class alignment;
 class base_format;
 class border;
 class cell_reference;
+class range_reference;
 class comment;
 class fill;
 class font;
@@ -517,6 +518,21 @@ public:
     /// from shared_formula_master().
     /// </summary>
     bool has_shared_formula() const;
+
+    /// <summary>
+    /// Returns true if this cell is covered by an array formula.
+    /// Every cell in an array formula's range reports the same formula(),
+    /// because the formula is one computation whose result spills across the
+    /// range. Use array_formula_range() to recover the block, and treat the
+    /// top-left cell of that range as the one that computes it.
+    /// </summary>
+    bool has_array_formula() const;
+
+    /// <summary>
+    /// The range an array formula spills across. Assumes has_array_formula()
+    /// is true.
+    /// </summary>
+    range_reference array_formula_range() const;
 
     /// <summary>
     /// The cell that carried this shared formula group's text. Assumes

--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -548,6 +548,16 @@ bool cell::has_shared_formula() const
     return d_->formula_.is_set() && d_->shared_formula_index_ != -1;
 }
 
+bool cell::has_array_formula() const
+{
+    return !d_->array_formula_ref_.empty();
+}
+
+range_reference cell::array_formula_range() const
+{
+    return range_reference(d_->array_formula_ref_);
+}
+
 cell_reference cell::shared_formula_master() const
 {
     const auto &masters = worksheet().d_->shared_formula_masters_;

--- a/source/detail/implementations/cell_impl.hpp
+++ b/source/detail/implementations/cell_impl.hpp
@@ -62,6 +62,10 @@ struct cell_impl
     optional<std::string> formula_;
     // -1 when the formula is not part of a shared group.
     int shared_formula_index_ = -1;
+    // The 'ref' of the array formula block covering this cell, empty when the
+    // cell is not part of one. Kept as text so this header needs no extra
+    // include; range_reference is reconstructed on access.
+    std::string array_formula_ref_;
     optional<hyperlink_impl> hyperlink_;
     format_impl_ptr format_;
     optional<comment *> comment_;

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -1462,6 +1462,11 @@ worksheet xlsx_consumer::read_worksheet_end(const std::string &rel_id)
             for (auto cell : row)
             {
                 cell.formula(array_formula.second);
+                // An array formula is one computation whose result spills over
+                // this range. Every cell in it reports the same formula, which
+                // without the range is indistinguishable from that many
+                // separate cells that happen to share one.
+                cell.d_->array_formula_ref_ = array_formula.first;
             }
         }
     }


### PR DESCRIPTION
An array formula's text is copied onto every cell of its ref range, and the range is then discarded. Copying the text matches what Excel displays; losing the range means a consumer cannot tell one computation from N duplicates.

Record the ref on cell_impl where the block is spread, and expose it:

  bool cell::has_array_formula() const;
  range_reference cell::array_formula_range() const;

formula() is unchanged and still returns the same text for every cell in the block. Nothing is removed and no existing behaviour changes.

Refs #6